### PR TITLE
feat: add Open Graph and Twitter metadata to templates

### DIFF
--- a/templates/art.html
+++ b/templates/art.html
@@ -2,8 +2,16 @@
 
 {% from "citation.html" import citation %}
 {% from "label.html" import label %}
+{% from "label_text.html" import label_text %}
 
 {% block title %}{{art.name}}{% endblock %}
+{% block og_title %}{{art.name}}{% endblock %}
+{% block og_description %}{% if art.name %}{{metadata.art_alias}}: {{ label_text(art, image) }}{% endblock %}
+{% block og_image%}{% if image.rights %}/image/{{image.id}}{% else %}{{image.page_url}}{% endif%}{% endblock %}
+{% block twitter_card %}summary_large_image{% endblock %}
+{% block twitter_title %}{{art.name}}{% endblock %}
+{% block twitter_description %}{{metadata.art_alias}}: {{ label_text(art, image) }}{% endblock %}
+{% block twitter_image%}{% if image.rights %}/image/{{image.id}}{% else %}{{image.page_url}}{% endif%}{% endblock %}
 {% block script %}
 {% if not metadata.minimal %}
 setupTagEditor({{art.id if metadata.mode == 'art' else image.id}}, "{{metadata.mode}}")

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,20 @@
     <link rel="stylesheet" type="text/css" href="/css">
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Forum&display=swap" rel="stylesheet">
+    
     <title>{{metadata.name}}: {% block title %}{% endblock %}</title>
+    
+    <!-- Open Graph Metadata -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="{{metadata.name}}: {% block og_title %}{% endblock %}" />
+    <meta property="og:description" content="{% block og_description %}{% endblock %}" />
+    <meta property="og:image" content="{% block og_image %}{% endblock %}" />
+    
+    <!-- Twitter Preview Metadata-->
+    <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}" />
+    <meta name="twitter:title" content="{{metadata.name}}: {% block twitter_title %}{% endblock %}" />
+    <meta name="twitter:description" content="{% block twitter_description %}{% endblock %}" />
+    <meta name="twitter:image" content="{% block twitter_image %}{% endblock %}" />
   </head>
   <body>
     <nav class="navbar navbar-expand-sm navbar-dark bg-dark">

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,6 +3,11 @@
 {% from "label.html" import label %}
 
 {% block title %}{% trans %}Home{% endtrans %}{% endblock %}
+{% block og_title %}{% trans %}Home{% endtrans %}{% endblock %}
+{% block og_description}{% include metadata.domain + '/intro.html' %}{% endblock %}
+{% block twitter_card %}summary{% endblock %}
+{% block twitter_title %}{% trans %}Home{% endtrans %}{% endblock %}
+{% block twitter_description %}{% include metadata.domain + '/intro.html' %}{% endblock %}
 {% block content %}
 {% if not metadata.minimal %}
   <div class="container-fluid px-0">

--- a/templates/label-text.html
+++ b/templates/label-text.html
@@ -1,0 +1,4 @@
+{% macro label_text(art, image, show_name=True) %}
+{%- if show_name -%}{%- if art.shelfmark %}{{art.shelfmark}} {% endif %}{% if art.name %}{{art.name|safe}}, {% elif art.form %}{{art.form}}, {% elif art.medium %}{{art.medium}}, {% endif %}{% endif %}{% if image.folio %}f{{image.folio}}{% if art.year_start %}, {% endif %}{% endif -%}
+{{art.year_start}}{{'-' if art and art.year_end and art.year_end > art.year_start}}{{art.year_end if art and art.year_end and art.year_end > art.year_start}}{% if art.country %}, {{art.country}}{% endif %}{% if image.attribution %}. © {{image.attribution}}{% endif -%}
+{% endmacro %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -4,6 +4,8 @@
 {% from "label.html" import label %}
 
 {% block title %}{% trans %}Search{% endtrans %}{% endblock %}
+{% block og_title %}{% trans %}Search{% endtrans %}{% endblock %}
+{% block twitter_title %}{% trans %}Search{% endtrans %}{% endblock %}
 {% block script %}
 {% if not metadata.minimal %}
 setupReset()

--- a/templates/sources.html
+++ b/templates/sources.html
@@ -3,6 +3,8 @@
 {% from "citation.html" import citation %}
 
 {% block title %}{% trans %}Sources{% endtrans %}{% endblock %}
+{% block og_title %}{% trans %}Sources{% endtrans %}{% endblock %}
+{% block twitter_title %}{% trans %}Sources{% endtrans %}{% endblock %}
 {% block content %}
 <h4>{% trans %}Sources{% endtrans %}</h4>
 <ul>

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}a
 
 {% block title %}{% trans %}Tags{% endtrans %}{% endblock %}
+{% block og_title %}{% trans %}Tags{% endtrans %}{% endblock %}
+{% block twitter_title %}{% trans %}Tags{% endtrans %}{% endblock %}
 {% block content %}
 <h4>{% trans %}Tags{% endtrans %}</h4>
 <div class="tag-list">


### PR DESCRIPTION
add metadata required to create pretty previews of shared links

Useful links:
- [The Open Graph protocol](https://ogp.me/)
- [About Twitter Cards](https://developer.x.com/en/docs/x-for-websites/cards/overview/abouts-cards)
